### PR TITLE
feat: Adding Table Heading Support and Formatting as Plain Markdown

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,3 +13,4 @@ categories = ["utilities"]
 
 [dependencies]
 anyhow = "1.0.56"
+pad = "0.1.6"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,12 +1,51 @@
-use std::fmt::Display;
+use std::{cmp, fmt::Display};
 
 use anyhow::{bail, Result};
+
+use pad::{Alignment, PadStr};
+
+#[derive(Debug, Clone)]
+pub enum HeadingAlignment {
+    Left,
+    Center,
+    Right,
+    Default,
+}
+
+impl HeadingAlignment {
+    fn to_padded_string(&self, length: usize) -> String {
+        match self {
+            HeadingAlignment::Default => "---".pad(length, '-', Alignment::Left, false),
+            HeadingAlignment::Left => ":--".pad(length, '-', Alignment::Left, false),
+            HeadingAlignment::Center => {
+                format!("{}:", ":-".pad(length - 1, '-', Alignment::Left, false))
+            }
+            HeadingAlignment::Right => "--:".pad(length, '-', Alignment::Right, false),
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct Heading {
+    label: String,
+    alignment: HeadingAlignment,
+}
+
+impl Heading {
+    pub fn new(label: String, alignment: Option<HeadingAlignment>) -> Self {
+        Self {
+            label,
+            alignment: alignment.unwrap_or(HeadingAlignment::Default),
+        }
+    }
+}
 
 #[derive(Debug, Clone)]
 pub struct MarkdownTable<T>
 where
     T: ToString + Display,
 {
+    headings: Option<Vec<Heading>>,
     cells: Vec<Vec<T>>,
 }
 
@@ -15,29 +54,98 @@ where
     T: ToString + Display,
 {
     pub fn new(cells: Vec<Vec<T>>) -> Self {
-        Self { cells }
+        Self {
+            cells,
+            headings: None,
+        }
+    }
+
+    pub fn with_headings(&mut self, headings: Vec<Heading>) -> &Self {
+        self.headings = Some(headings);
+        self
     }
 
     pub fn as_markdown(&self) -> Result<String> {
-        if !self.cells.is_empty() {
-            Ok(format!(
-                "<table>{}</table>",
-                self.cells
+        match &self.headings {
+            Some(headings) => {
+                let mut col_width: Vec<usize> = headings
+                    .into_iter()
+                    .map(|h| cmp::max(5, h.label.len()))
+                    .collect();
+
+                for row in &self.cells {
+                    for (col_index, value) in row.iter().enumerate() {
+                        // TODO using tostring,  may be not good as mutliline string will break it
+                        let value_len = value.to_string().len();
+                        if value_len > col_width[col_index] {
+                            col_width[col_index] = value_len;
+                        }
+                    }
+                }
+                let header_row = format!(
+                    "|{}|",
+                    headings
+                        .into_iter()
+                        .enumerate()
+                        .map(|(i, h)| format!(" {} ", h.label).pad_to_width(col_width[i]))
+                        .collect::<Vec<String>>()
+                        .join("|")
+                );
+                let header_split_row = format!(
+                    "|{}|",
+                    headings
+                        .into_iter()
+                        .enumerate()
+                        .map(|(i, h)| format!(
+                            " {} ",
+                            h.alignment.to_padded_string(col_width[i] - 2)
+                        ))
+                        .collect::<Vec<String>>()
+                        .join("|")
+                );
+                let cells_row = self
+                    .cells
                     .iter()
                     .map(|v| {
                         format!(
-                            "<tr>{}",
+                            "|{}|",
                             v.iter()
-                                .map(|v_inner| format!("<td>{}", v_inner))
+                                .enumerate()
+                                .map(|(i, v_inner)| format!(" {} ", v_inner)
+                                    .pad_to_width(col_width[i]))
                                 .collect::<Vec<String>>()
-                                .join("")
+                                .join("|")
                         )
                     })
                     .collect::<Vec<String>>()
-                    .join(""),
-            ))
-        } else {
-            bail!("Table must have at least 1 row.".to_string())
+                    .join("\n");
+                Ok(format!(
+                    "{}\n{}\n{}\n",
+                    header_row, header_split_row, cells_row
+                ))
+            }
+            None => {
+                if !self.cells.is_empty() {
+                    Ok(format!(
+                        "<table>{}</table>",
+                        self.cells
+                            .iter()
+                            .map(|v| {
+                                format!(
+                                    "<tr>{}",
+                                    v.iter()
+                                        .map(|v_inner| format!("<td>{}", v_inner))
+                                        .collect::<Vec<String>>()
+                                        .join("")
+                                )
+                            })
+                            .collect::<Vec<String>>()
+                            .join(""),
+                    ))
+                } else {
+                    bail!("Table must have at least 1 row.".to_string())
+                }
+            }
         }
     }
 }

--- a/tests/markdown_test.rs
+++ b/tests/markdown_test.rs
@@ -2,7 +2,7 @@
 mod tests {
     use anyhow::Result;
 
-    use markdown_table::MarkdownTable;
+    use markdown_table::{Heading, MarkdownTable};
 
     const TEST_TABLE: &str = "<table><tr><td>0<tr><td>1<tr><td>2</table>";
 
@@ -33,5 +33,63 @@ mod tests {
         } else {
             panic!("Test should not reach this branch.")
         }
+    }
+
+    #[test]
+    fn test_table_with_small_headings() {
+        let md: String = MarkdownTable::new(vec![vec!["1", "2", "3", "4"]])
+            .with_headings(vec![
+                Heading::new("1".to_string(), None),
+                Heading::new(
+                    "2".to_string(),
+                    Some(markdown_table::HeadingAlignment::Left),
+                ),
+                Heading::new(
+                    "3".to_string(),
+                    Some(markdown_table::HeadingAlignment::Right),
+                ),
+                Heading::new(
+                    "4".to_string(),
+                    Some(markdown_table::HeadingAlignment::Center),
+                ),
+            ])
+            .as_markdown()
+            .unwrap();
+
+        let expected: &str = r#"| 1   | 2   | 3   | 4   |
+| --- | :-- | --: | :-: |
+| 1   | 2   | 3   | 4   |
+"#;
+
+        assert_eq!(md, expected.to_string());
+    }
+
+    #[test]
+    fn test_table_with_headings() {
+        let md: String = MarkdownTable::new(vec![vec!["Val 1", "Val 2", "Val 3", "Val 4"]])
+            .with_headings(vec![
+                Heading::new("Default Header".to_string(), None),
+                Heading::new(
+                    "Left Align".to_string(),
+                    Some(markdown_table::HeadingAlignment::Left),
+                ),
+                Heading::new(
+                    "Right Align".to_string(),
+                    Some(markdown_table::HeadingAlignment::Right),
+                ),
+                Heading::new(
+                    "Center Align".to_string(),
+                    Some(markdown_table::HeadingAlignment::Center),
+                ),
+            ])
+            .as_markdown()
+            .unwrap();
+
+        let expected: &str = r#"| Default Header | Left Align | Right Align | Center Align |
+| ------------ | :------- | --------: | :--------: |
+| Val 1        | Val 2    | Val 3     | Val 4      |
+"#;
+
+        assert_eq!(md, expected.to_string());
     }
 }


### PR DESCRIPTION
## Adding Table Heading Support and Formatting as Plain Markdown

### Description
This pull request aims to enhance the functionality of the project by introducing the ability to include table headings when generating markdown tables. Additionally, it ensures that the resulting table is formatted as a plain markdown table, conforming to the standard markdown syntax.

### Changes Made
- Implemented the logic to allow the addition of table headings.
- Updated the table rendering function to format the output as a plain markdown table when headings are present.

### Motivation
The addition of table headings significantly improves the readability and organization of tabular data presented using markdown tables. By providing clear labels or titles for each column, it becomes easier for users to understand and interpret the information contained within the table. Formatting the output as a plain markdown table ensures consistency and compatibility with existing markdown parsers and rendering engines.

Please review these changes and let me know if any further modifications are required.