### PR TITLE
Fix bug when column width is bigger than 5

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -70,13 +70,13 @@ where
             Some(headings) => {
                 let mut col_width: Vec<usize> = headings
                     .iter()
-                    .map(|h| cmp::max(5, h.label.len()))
+                    .map(|h| cmp::max(5, h.label.len() + 2))
                     .collect();
 
                 for row in &self.cells {
                     for (col_index, value) in row.iter().enumerate() {
                         // TODO using tostring,  may be not good as mutliline string will break it
-                        let value_len = value.to_string().len();
+                        let value_len = value.to_string().len() + 2;
                         if value_len > col_width[col_index] {
                             col_width[col_index] = value_len;
                         }

--- a/tests/markdown_test.rs
+++ b/tests/markdown_test.rs
@@ -86,8 +86,38 @@ mod tests {
             .unwrap();
 
         let expected: &str = r#"| Default Header | Left Align | Right Align | Center Align |
-| ------------ | :------- | --------: | :--------: |
-| Val 1        | Val 2    | Val 3     | Val 4      |
+| -------------- | :--------- | ----------: | :----------: |
+| Val 1          | Val 2      | Val 3       | Val 4        |
+"#;
+
+        assert_eq!(md, expected.to_string());
+    }
+
+
+    #[test]
+    fn test_table_with_long_values() {
+        let md: String = MarkdownTable::new(vec![vec!["value bigger than header 1", "value bigger than header 2", "value bigger than header 3", "value bigger than header 4"]])
+            .with_headings(vec![
+                Heading::new("Default Header".to_string(), None),
+                Heading::new(
+                    "Left Align".to_string(),
+                    Some(markdown_table::HeadingAlignment::Left),
+                ),
+                Heading::new(
+                    "Right Align".to_string(),
+                    Some(markdown_table::HeadingAlignment::Right),
+                ),
+                Heading::new(
+                    "Center Align".to_string(),
+                    Some(markdown_table::HeadingAlignment::Center),
+                ),
+            ])
+            .as_markdown()
+            .unwrap();
+
+        let expected: &str = r#"| Default Header             | Left Align                 | Right Align                | Center Align               |
+| -------------------------- | :------------------------- | -------------------------: | :------------------------: |
+| value bigger than header 1 | value bigger than header 2 | value bigger than header 3 | value bigger than header 4 |
 "#;
 
         assert_eq!(md, expected.to_string());


### PR DESCRIPTION
The column width is based on the longest value of a column. Currently, the width is missing two characters due to the two space starting & ending the value. This PR aims to fix this issue.